### PR TITLE
[OUTDATED] Change the `:J describe` behaviour to open an editable buffer instead of an input box

### DIFF
--- a/lua/jj/cmd.lua
+++ b/lua/jj/cmd.lua
@@ -634,14 +634,30 @@ function M.describe(description, opts)
 	end
 end
 
---- Jujutsu status
-function M.status()
+--- Jujutsu status.
+--
+--  it executes `jj st` and either:
+--   1. Shows the output in a notification (if `opts.notify` is true), or
+--   2. Displays it in the buffer by default.
+--
+-- @param opts? table Optional settings:
+-- @field notify boolean If true, show the status in a notification instead of buffer.
+function M.status(opts)
 	if not utils.ensure_jj() then
 		return
 	end
 
 	local cmd = "jj st"
-	run(cmd)
+
+	if opts and opts.notify then
+		local output = utils.execute_command(cmd, "Failed to get status")
+		if output then
+			utils.notify(output, vim.log.levels.INFO)
+		end
+	else
+		-- Default behavior: show in buffer
+		run(cmd)
+	end
 end
 
 --- @class jj.cmd.new_opts


### PR DESCRIPTION
This PR changes the `:J describe` behaviour when no description is provided to open an editable buffer inline to more closely match the default behaviour of both `https://github.com/tpope/vim-fugitive` and `jj describe`

I left the previous code as a comment, maybe we can envision way to let people opt-in/opt-out of the new "buffer edit" mode:
>-- TODO maybe add an option to pick between buffer editing and description input box?

# New behaviour
When running `:J describe` without entering a message, a new writable in-memory buffer is opened, letting the user write longer descriptions and navigate in the message. 

The editable buffer shows the following message:
```txt
JJ: This commit contains the following changes:
JJ:     M lua/jj/cmd.lua
JJ:
JJ: Lines starting with "JJ:" (like this one) will be ignored when finalizing
```
The middle lines list the updated files (as provided by `jj diff --name-only`)

When the user has finished writing the message, he can "commit" the description with `:wq` or `:w`

# New util
- get_modified_files(): Get a list of files modified in the current jj repository. (calls jj diff --name-only) and returns the result

# Changes:
- status: NON BREAKING change to status, added an option to show the status output in the notification bar, rather than into a new buffer