### PR TITLE
feat: `:J desc` short hand for `describe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This plugin aims to be something like vim-fugitive but for driving the jj-vcs CL
 - Terminal-based output display for jj commands
 - Support jj subcommands including your aliases through the cmdline.
 - First class citizens with ui integration
-  - `describe` - Set change descriptions with a Git-style commit message editor
+  - `describe` / `desc` - Set change descriptions with a Git-style commit message editor
   - `status` / `st` - Show repository status
   - `log` - Display log history with configurable options
   - `diff` - Show changes

--- a/lua/jj/cmd.lua
+++ b/lua/jj/cmd.lua
@@ -912,7 +912,7 @@ function M.j(args)
 	local cmd = string.format("jj %s", cmd_args)
 
 	-- Handle known subcommands with custom logic
-	if subcommand == "describe" then
+	if subcommand == "describe" or subcommand == "desc" then
 		local description = table.concat(remaining_args, " ")
 		M.describe(description ~= "" and description or nil)
 		return


### PR DESCRIPTION
Awesome library!

I typically run `jj desc` which is missing from this plugin so I thought I would contribute.

Thanks!