### PR TITLE
Minor fix: change "JJ log all" revisions to "'all()'" in example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ require("jj").setup({
     -- Some functions like `describe` or `log` can take parameters
     vim.keymap.set("n", "<leader>jL", function()
       jj.log {
-        revisions = "all()",
+        revisions = "'all()'", -- equivalent to jj log -r ::
       }
     end, { desc = "JJ log all" })
 


### PR DESCRIPTION
Fix "JJ log all" revisions from 
```
revisions = "all()"
``` 
to
```
revisions = "'all()'"
```
which plays better with jj `0.35.0`;

```
> jj log -r all()
error: a value is required for '--revisions <REVSETS>' but none was supplied

For more information, try '--help'.

> jj log -r 'all()'
# succesfull command
```