### PR TITLE
feat(describe): Add `describe_quit_on_esc option`

### DIFF
--- a/lua/jj/init.lua
+++ b/lua/jj/init.lua
@@ -20,6 +20,8 @@ M.config = {
 	},
 	--- @type string Editor mode for describe command: "buffer" (Git-style editor) or "input" (simple input prompt)
 	describe_editor = "buffer",
+	--- @type boolean This enables or disables quitting the `jj describe` buffer by hitting `<Esc>`
+	describe_quit_on_esc = true,
 }
 
 --- Setup the plugin
@@ -29,11 +31,13 @@ function M.setup(opts)
 
 	picker.setup(opts and opts.picker or {})
 	utils.setup({ highlights = M.config.highlights })
-	
+
 	-- Pass describe_editor config to cmd module
 	if opts and opts.describe_editor then
 		cmd.config.describe_editor = opts.describe_editor
 	end
+	-- Pass describe_quit_on_esc config to cmd module, default true
+	cmd.config.describe_quit_on_esc = not (opts and opts.describe_quit_on_esc == false)
 
 	cmd.register_command()
 end

--- a/lua/jj/utils.lua
+++ b/lua/jj/utils.lua
@@ -209,9 +209,26 @@ function M.notify(message, level)
 	vim.notify(message, level, { title = "JJ", timeout = 3000 })
 end
 
----@param initial_text string[] Lines to initialize the buffer with
----@param on_done fun(buf: string[])? Optional callback called with user text on buffer write
-function M.open_ephemeral_buffer(initial_text, on_done)
+--- @class open_ephemeral_buffer_opts
+---@field initial_text string[]? Lines to initialize the buffer with
+---@field quit_on_esc boolean? Optional enable or disable quitting the ephemeral buffer by hitting `<Esc>`
+---@field on_done fun(buf: string[])? Optional callback called with user text on buffer write
+
+--- @type open_ephemeral_buffer_opts
+local default_open_ephemeral_buffer_opts = {
+	initial_text = {},
+	on_done = nil,
+	quit_on_esc = true
+}
+
+---@param opts open_ephemeral_buffer_opts? Options
+function M.open_ephemeral_buffer(opts)
+	opts = opts or default_open_ephemeral_buffer_opts
+
+	local initial_text = opts.initial_text
+	local on_done = opts.on_done
+	local quit_on_esc = opts.quit_on_esc
+
 	-- Initialize highlight groups once
 	init_highlights()
 
@@ -332,13 +349,15 @@ function M.open_ephemeral_buffer(initial_text, on_done)
 		{ buffer = buf, noremap = true, silent = true, desc = "Close describe buffer" }
 	)
 
-	-- Add keymap to close the buffer with '<Esc>' in normal mode
-	vim.keymap.set(
-		"n",
-		"<Esc>",
-		"<cmd>close!<CR>",
-		{ buffer = buf, noremap = true, silent = true, desc = "Close describe buffer" }
-	)
+	if (quit_on_esc) then
+		-- Add keymap to close the buffer with '<Esc>' in normal mode
+		vim.keymap.set(
+			"n",
+			"<Esc>",
+			"<cmd>close!<CR>",
+			{ buffer = buf, noremap = true, silent = true, desc = "Close describe buffer" }
+		)
+	end
 end
 
 --- Parse the current line in the jj status buffer to extract file information.


### PR DESCRIPTION
This PR adds a new `describe_quit_on_esc` plugin configuration option that makes it possible for the user to control whether the `jj describe` buffer is closed by hitting `<Esc>` in normal mode.

I personally found it very infuriating to lose the describe message every time I hit `<Esc>` twice by accident, this happens rather frequently, especially when typing fast.

I kept the current behavior (i.e. quitting the describe buffer by hitting Esc in normal mode) the default, so current configurations will not experience behavior changes.

@NicolasGB Please let me know if you want to change the default behavior