### PR TITLE
fix: Correctly parse complex subcommands and push a table to `terminal.run()` when it's possible instead of making a concat

### DIFF
--- a/lua/jj/ui/terminal.lua
+++ b/lua/jj/ui/terminal.lua
@@ -329,3 +329,4 @@ function M.run(cmd, keymaps)
 end
 
 return M
+


### PR DESCRIPTION
Closes #38 