### PR TITLE
feat(terminal): add configurable cursor render delay for terminal buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ The plugin also provides `:Jdiff`, `:Jvdiff`, and `:Jhdiff` commands for diffing
     renamed = { fg = "#d29922", ctermfg = "Yellow" },   -- Renamed files
   },
 
+  -- Configure terminal behavior
+  terminal = {
+    -- Cursor render delay in milliseconds (default: 10)
+    -- If cursor column is being reset to 0 when refreshing commands, try increasing this value
+    -- This delay allows the terminal emulator to complete rendering before restoring cursor position
+    cursor_render_delay = 10,
+  },
+
   -- Configure cmd module (describe editor, keymaps)
   cmd = {
     -- Configure describe editor
@@ -305,6 +313,9 @@ jj.diff.hsplit({ rev = "@-2" })   -- Horizontal split against @-2
   config = function()
     local jj = require("jj")
     jj.setup({
+      terminal = {
+        cursor_render_delay = 10, -- Adjust if cursor position isn't restoring correctly
+      },
       cmd = {
         describe = {
           editor = {

--- a/lua/jj/cmd/describe.lua
+++ b/lua/jj/cmd/describe.lua
@@ -124,10 +124,7 @@ function M.describe(description, revset, opts)
 		end, function()
 			if open_log_on_close then
 				vim.schedule(function()
-					vim.o.lazyredraw = true
 					cmd.log({})
-					vim.o.lazyredraw = false
-					vim.cmd("redraw!")
 				end)
 			end
 		end, describe_editor_keymaps())

--- a/lua/jj/cmd/log.lua
+++ b/lua/jj/cmd/log.lua
@@ -15,7 +15,7 @@ local terminal = require("jj.ui.terminal")
 --- @field raw_flags? string
 
 ---@type jj.cmd.log_opts
-local default_log_opts = { summary = false, reversed = false, no_graph = false, limit = 20, raw_flats = nil }
+local default_log_opts = { summary = false, reversed = false, no_graph = false, limit = 20, raw_flags = nil }
 
 --- Jujutsu log
 --- @param opts? jj.cmd.log_opts Optional command options
@@ -24,12 +24,17 @@ function M.log(opts)
 		return
 	end
 
+	-- If a log was already being displayed before this command we will want to maintain the cursor position
+	if terminal.state.buf_cmd == "log" then
+		terminal.store_cursor_position()
+	end
+
 	local jj_cmd = "jj log"
 	local merged_opts = vim.tbl_extend("force", default_log_opts, opts or {})
 
 	-- If a raw has been given simply execute it as is
-	if merged_opts.raw then
-		return terminal.run(string.format("%s %s", jj_cmd, merged_opts.raw), M.log_keymaps())
+	if merged_opts.raw_flags then
+		return terminal.run(string.format("%s %s", jj_cmd, merged_opts.raw_flags), M.log_keymaps())
 	end
 
 	for key, value in pairs(merged_opts) do

--- a/lua/jj/init.lua
+++ b/lua/jj/init.lua
@@ -2,12 +2,15 @@ local M = {}
 local cmd = require("jj.cmd")
 local picker = require("jj.picker")
 local editor = require("jj.ui.editor")
+local terminal = require("jj.ui.terminal")
 
 --- Jujutsu plugin configuration
 --- @class jj.Config
 --- @field cmd? jj.cmd.opts Options for command module
 --- @field picker? jj.picker.config Options for picker module
+--- @field terminal? jj.ui.terminal.opts Options for the terminal
 --- @field highlights? jj.ui.editor.highlights Highlight configuration for describe buffer
+
 M.config = {
 	-- Default configuration
 	--- @type jj.picker.config
@@ -27,6 +30,7 @@ function M.setup(opts)
 	picker.setup(opts and opts.picker or {})
 	editor.setup({ highlights = M.config.highlights })
 	cmd.setup(opts and opts.cmd or {})
+	terminal.setup(opts and opts.terminal or {})
 
 	cmd.register_command()
 end


### PR DESCRIPTION
 Add cursor position restoration with configurable timing to handle terminal
     buffer rendering asynchronously. This fixes cursor column being reset to 0
     when refreshing jj log commands.

     Changes:
     - Add `terminal.cursor_render_delay` configuration option (default: 10ms)
     - Add buffer.get_cursor() and buffer.set_cursor() helpers in core/buffer
       * buffer.set_cursor() uses defer_fn with configurable delay for terminal buffers
       * Automatic position validation with clamping to buffer bounds * Line number clamped to [1, line_count] * Column clamped to [0, line_length] based on actual line content * Validation happens inside deferred callback to check against final rendered content - Extract clamp_cursor_position() helper to eliminate code duplication - Refactor terminal module to use new buffer cursor helpers - Store and restore cursor position when cycling through log commands - Update README with terminal configuration section and example usage

     The delay is necessary because nvim_open_term() + nvim_chan_send() have
     asynchronous rendering in the terminal emulator layer. Setting the cursor
     before rendering completes results in the column being reset to 0. Users
     experiencing issues can increase the delay value if needed.