### PR TITLE
feat: add close_on_edit config for log buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ The plugin also provides `:Jdiff`, `:Jvdiff`, and `:Jhdiff` commands for diffing
       }
     },
 
+    -- Configure log command behavior
+    log = {
+      close_on_edit = false,                -- Close log buffer after editing a change
+    },
+
     -- Configure keymaps for command buffers
     keymaps = {
       -- Log buffer keymaps (set to nil to disable)


### PR DESCRIPTION
- Add close_on_edit option to close log buffer after editing a change
- Rename handle_log_enter to handle_log_edit with close_on_exit parameter
- Update log keymaps to pass close_on_edit config to handlers
- Update config types and defaults in init.lua

tl;dr By default now it stays open the ux is better but if people want the old behaviour they can opt in with the new config

Closes #46 