### PR TITLE
feat(describe): set the local filetype of the editor describe to jjdescription

### DIFF
--- a/lua/jj/ui/editor.lua
+++ b/lua/jj/ui/editor.lua
@@ -124,6 +124,7 @@ function M.open_editor(initial_text, on_done, on_unload, keymaps)
 		name = "jujutsu:///DESCRIBE_EDITMSG",
 		split = "horizontal",
 		size = math.floor(vim.o.lines / 2),
+		filetype = "jjdescription",
 		buftype = "acwrite",
 		modifiable = true,
 		keymaps = keymaps,


### PR DESCRIPTION
Neovim upstream has had [an ftplugin for `jjdescription`](https://github.com/neovim/neovim/commit/b365036ab3f5e91439a5397ed0f32b651d60f08c) since v0.11.0.

I thought this would be a nice QOL change to enable FileType autocommands in the describe buffer.