### PR TITLE
Add --no-pager to the log diff handler

### DIFF
--- a/lua/jj/cmd/log.lua
+++ b/lua/jj/cmd/log.lua
@@ -108,7 +108,7 @@ function M.handle_log_diff()
 	local revset = parser.get_rev_from_log_line(line)
 
 	if revset then
-		local cmd = string.format("jj show %s", revset)
+		local cmd = string.format("jj show --no-pager %s", revset)
 		terminal.run_floating(cmd, require("jj.cmd").floating_keymaps())
 	else
 		utils.notify("No valid revision found in the log line", vim.log.levels.ERROR)


### PR DESCRIPTION
With paging (the default) there is no way to see diffs longer that that which fits in the floating terminal window. Using --no-pager shows the entire diff.