### PR TITLE
Terminal buffer keymap help

### DIFF
--- a/lua/jj/ui/terminal.lua
+++ b/lua/jj/ui/terminal.lua
@@ -50,6 +50,78 @@ function M.setup(user_opts)
 	opts = vim.tbl_deep_extend("force", opts, user_opts or {})
 end
 
+--- Help for terminal buffer
+function M.keymap_help()
+    -- get the normal mode keys defined for the current buffer
+    local keys = vim.api.nvim_buf_get_keymap(0, "n")
+
+    -- sort the keys table by desc
+    table.sort(keys, function(a, b) return (a.desc or "") < (b.desc or "") end)
+
+    -- Figure out the width of the longest key for later formatting
+    -- Ignore keys for entries without a desc
+    local max_key_width = 0
+    for _, mapping in ipairs(keys) do
+      local desc = mapping["desc"]
+      if desc ~= nil then
+        local key = mapping["lhs"]
+        local key_width = vim.api.nvim_strwidth(key)
+        if key_width > max_key_width then
+          max_key_width = key_width
+        end
+      end
+    end
+
+    -- create a buffer and floating window to show the key mappings
+    local buf, win = buffer.create_float({
+        title = " Key mappings ",
+        title_pos = "left",
+		enter = true,
+		bufhidden = "hide",
+		win_options = {
+			wrap = true,
+			number = false,
+			relativenumber = false,
+			cursorline = false,
+			signcolumn = "no",
+		},
+    })
+
+    -- helper function to pad a given key with spaces if necessary such that
+    -- its size will match max_key_width calculated above.
+    local function space_pad(key)
+      local key_width = vim.api.nvim_strwidth(key)
+      local delta = max_key_width - key_width
+      if delta > 0 then
+        return key .. string.rep(" ", delta)
+      end
+      return key
+    end
+
+    -- create formated entries for items with a non-nil desc
+    local lines = {}
+    for _, entry in ipairs(keys) do
+      if entry["desc"] ~= nil then
+        local line = string.format("  %s   %s",
+                                   space_pad(entry["lhs"]),
+                                   entry["desc"])
+        table.insert(lines, line)
+      end
+
+    end
+
+    -- add some helper text at the end
+    table.insert(lines, "")
+    table.insert(lines, '   Use "q" or ESC to close this window')
+
+    -- add the formatted lines to the buffer
+    vim.api.nvim_buf_set_lines(buf, 3, -1, false, lines)
+
+    -- Use q or ESC to close the buffer
+    vim.keymap.set("n", "q", "<cmd>close<CR>", { buffer = buf })
+    vim.keymap.set("n", "<Esc>", "<cmd>close<CR>", { buffer = buf })
+end
+
 --- Close the current terminal buffer if it exists
 function M.close_terminal_buffer()
 	buffer.close(state.buf)
@@ -338,6 +410,7 @@ function M.run(cmd, keymaps)
 	-- Set base keymaps only if they haven't been set for this buffer yet
 	if not vim.b[state.buf].jj_keymaps_set then
 		buffer.set_keymaps(state.buf, {
+            { modes = { "n" }, lhs = "g?", rhs = M.keymap_help },
 			-- Disable insert, command and append modes
 			{ modes = { "n", "v" }, lhs = "i", rhs = function() end },
 			{ modes = { "n", "v" }, lhs = "c", rhs = function() end },


### PR DESCRIPTION
I'm an old guy and one of the downsides is it is harder to remember rarely used key mappings.  There is only so much space on my monitor for yellow stickies containing key hints.  Built in help is better.

This PR, if accepted, adds a floating help window to terminals created for the log and status keymaps.  I hardcoded `g?` to trigger help.  It calls a new terminal function that reads the normal mode buffer keymap, sorts it by description, then lists the keys that have a description in a floating window.

<img width="978" height="620" alt="Screenshot 2026-01-02 at 10 06 11 AM" src="https://github.com/user-attachments/assets/17204196-4c0b-4283-9804-f953b54018e9" />

