### PR TITLE
feat(log): add immutable-ignoring rebase keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ Once in rebase mode, the interface highlights your selection and the current reb
 From rebase mode, choose how to rebase:
 
 - `<CR>` or `o` - Rebase onto (`-o`) the revision under cursor
-- `a` or `A` - Rebase after (`-A`) the revision under cursor
-- `b` or `B` - Rebase before (`-B`) the revision under cursor
+- `a` - Rebase after (`-A`) the revision under cursor
+- `b` - Rebase before (`-B`) the revision under cursor
+- `<S-CR>` or `<S-o>` - Rebase onto (`-o`) ignoring immutability
+- `<S-a>` - Rebase after (`-A`) ignoring immutability
+- `<S-b>` - Rebase before (`-B`) ignoring immutability
 - `<Esc>` or `<C-c>` - Exit rebase mode without making changes
 
 **Visual mode selection:** Select multiple revisions in visual mode before pressing `r` to rebase them all at once. The plugin extracts each selected revision and rebases them together.
@@ -300,9 +303,12 @@ The plugin also provides `:Jdiff`, `:Jvdiff`, and `:Jhdiff` commands for diffing
         open_pr_list = "<S-o>",             -- Open PR/MR by selecting from all bookmarks
         rebase = "r",                       -- Enter rebase mode targeting revision under cursor or selected revisions
         rebase_mode = {
-            onto = { "<CR>", "o" },           -- Select revision under cursor as rebase destination
+            onto = { "<CR>", "o" },           -- Select revision under cursor as rebase onto destination
             after = { "a", "A" },             -- Rebase after revision under cursor
             before = { "b", "B" },            -- Rebase before revision under cursor
+            onto_immutable = { "<S-CR>", "<S-o>" }, -- Select revision  as a rebase onto destination (ignore immutability)
+            after_immutable = "<S-a>",              -- Rebase after revision under cursor (ignore immutability)
+            before_immutable = "<S-b>",             -- Rebase before revision under cursor (ignore immutability)
             exit_mode = { "<Esc>", "<C-c>" }, -- Exit rebase mode
         },
       },

--- a/lua/jj/cmd/init.lua
+++ b/lua/jj/cmd/init.lua
@@ -52,6 +52,9 @@ local status_module = require("jj.cmd.status")
 --- @field onto? string|string[]
 --- @field after? string|string[]
 --- @field before? string|string[]
+--- @field onto_immutable? string|string[]
+--- @field after_immutable? string|string[]
+--- @field before_immutable? string|string[]
 --- @field exit_mode? string|string[]
 
 --- @class jj.cmd.bookmark
@@ -128,8 +131,11 @@ M.config = {
 			rebase = "r",
 			rebase_mode = {
 				onto = { "<CR>", "o" },
-				after = { "a", "A" },
-				before = { "b", "B" },
+				after = "a",
+				before = "b",
+				onto_immutable = { "<S-CR>", "<S-o>" },
+				after_immutable = "<S-a>",
+				before_immutable = "<S-b>",
 				exit_mode = { "<Esc>", "<C-c>" },
 			},
 		},

--- a/lua/jj/core/buffer.lua
+++ b/lua/jj/core/buffer.lua
@@ -447,9 +447,9 @@ function M.set_cursor(buf, pos, opts)
 		return
 	end
 
-	-- For terminal buffers, delay to allow rendering to complete
-	-- Must validate position INSIDE the deferred function for terminal buffers
-	-- because the buffer content may not be stable yet
+	-- For terminal buffers, we delay cursor positioning to allow async rendering to complete.
+	-- The position is validated inside the deferred function because buffer content
+	-- may not be stable at function call time
 	if vim.bo[buf].buftype == "terminal" or delay > 0 then
 		vim.defer_fn(function()
 			if not vim.api.nvim_buf_is_valid(buf) or not vim.api.nvim_win_is_valid(winid) then


### PR DESCRIPTION
Changes add support for rebasing while ignoring immutability constraints with new keymaps (<S-CR>, <S-o>, <S-a>, <S-b>) and update documentation. Refactors rebase handler to accept optional ignore_immut parameter and includes minor comment improvements in buffer and command modules.