### PR TITLE
feat(cmd): Add option to set describe type for cmd

### DIFF
--- a/lua/jj/cmd/describe.lua
+++ b/lua/jj/cmd/describe.lua
@@ -9,6 +9,7 @@ local editor = require("jj.ui.editor")
 
 --- @class jj.cmd.describe_opts
 --- @field with_status boolean: Whether or not `jj st` should be displayed in a buffer while describing the commit
+--- @field type? "buffer"|"input" Editor mode for describe command: "buffer" (Git-style editor) or "input" (simple input prompt)
 --- @type jj.cmd.describe_opts
 local default_describe_opts = {
 	with_status = true,
@@ -69,9 +70,10 @@ function M.describe(description, revset, opts)
 	end
 
 	local cmd = require("jj.cmd")
+	local merged_opts = vim.tbl_deep_extend("force", default_describe_opts, opts or {})
 
 	-- Use buffer editor mode (defaults to "buffer" if not configured)
-	local editor_mode = cmd.config.describe.editor.type or "buffer"
+	local editor_mode = merged_opts.type or cmd.config.describe.editor.type or "buffer"
 	if editor_mode == "buffer" then
 		local jj_cmd = "jj log -r " .. revset .. " --no-graph -T 'coalesce(description, \"\n\")'"
 		local old_description_raw, success = runner.execute_command(jj_cmd, "Failed to get old description")
@@ -129,7 +131,6 @@ function M.describe(description, revset, opts)
 		end, describe_editor_keymaps())
 	else
 		-- Use input mode
-		local merged_opts = vim.tbl_deep_extend("force", default_describe_opts, opts or {})
 		if merged_opts.with_status then
 			-- Show the status in a terminal buffer
 			cmd.status()


### PR DESCRIPTION
Adds the global option `describe.editor.type` to the exposed describe command api, so it can be executed e.g. with:

`require("jj.cmd").describe(nil,nil,{with_status=false,type="input"})`

This allows having different types of describe commands invoked in a single setting, without having to change the global plugin option.

Takes the same two option enums as the global variable, "buffer" or "input". Is an optional field, which is given precedence to the older order of setting the variable. That order remains the same (command option -> global option -> "buffer" default).

Some drawbacks of this implementation:

- For now, to access the option I have simply copy-pasted the global 'editor.type' field and field description - less DRY.
- Perhaps very slight performance hit for buffer-style message editing as we need to merge the opts-dict _before_ seeing which style the user wants
- And the invocation itself is a little awkward with (nil, nil, {with_status=... required alongside the 'type=' option. This could be fixed as part of another PR however, did not want to change too much at once here.

Fixes #68 