### PR TITLE
fix(commit): Migrate from simulated commit to jj's native command

### DIFF
--- a/lua/jj/ui/terminal.lua
+++ b/lua/jj/ui/terminal.lua
@@ -207,6 +207,15 @@ function M.restore_cursor_position()
 	state.cursor_restore_pos = nil
 end
 
+--- Check whether the log buffer is currently active
+--- @return boolean
+function M.is_log_buffer_open()
+	if not state.buf or not vim.api.nvim_buf_is_valid(state.buf) then
+		return false
+	end
+	return state.buf_cmd == "log"
+end
+
 --- Run the command in a floating window
 --- @param cmd string The command to run in the floating window
 --- @param keymaps jj.core.buffer.keymap[]|nil Additional keymaps to set for this floating buffer


### PR DESCRIPTION
    - This required some improvements on the editor buffer logic, introduced a `on_write` (previously on_done but it wasn't the right meaning) hook and an `on_unload` to allow for both describe and commit correct workflows.
    - Introduced an utils function to extract the description text and clean it post buffer write