### PR TITLE
Use the real files when diffing against current revision

### DIFF
--- a/lua/jj/diff/codediff.lua
+++ b/lua/jj/diff/codediff.lua
@@ -17,6 +17,14 @@ local function diff_two_changes(left, right)
 		return
 	end
 
+	--- Omit the commit id when left is the current revision,
+	--- allowing codediff to use the actual file instead of a virtual buffer.
+	local commit_id_current = utils.get_current_commit_id()
+	if commit_id_current == commit_id_left then
+		vim.cmd(string.format("CodeDiff %s", commit_id_right))
+		return
+	end
+
 	vim.cmd(string.format("CodeDiff %s %s", commit_id_right, commit_id_left))
 end
 

--- a/lua/jj/utils.lua
+++ b/lua/jj/utils.lua
@@ -370,6 +370,24 @@ function M.get_commit_id(revset)
 	return vim.trim(output)
 end
 
+---
+--- Get the commit id of the current revision
+--- @return string|nil
+function M.get_current_commit_id()
+	local output, success = runner.execute_command(
+		"jj log --no-graph -r '@' -T 'commit_id' --quiet",
+		"Error extracting current revision's commit id",
+		nil,
+		true
+	)
+
+	if not success or not output then
+		return nil
+	end
+
+	return vim.trim(output)
+end
+
 --- Extract the description from the describe text
 --- @param lines string[] The lines of a described change
 --- @return string|nil


### PR DESCRIPTION
This allows users to get lsp functionalities and run `gf` to navigate to the file in a different tab.