### PR TITLE
feat(tag): Implement set/delete/push (only colocated repistories)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,9 @@ You can fetch and push directly from the log buffer:
 
 ### Manage tags from the log buffer
 
-- `tt` - Create a new tag on the revision under cursor
-- `td` - Delete an existing tag via picker
-- `tp` - Push a tag to a remote (colocated repositories only)
+- `<S-t>` - Create a new tag on the revision under cursor
 
-Tag push uses `git push` under the hood and is only available in colocated repositories. If multiple remotes are configured, you'll be prompted to select one.
+Deleting and pushing tags (for colocated repositories) is also supported and changes are reflected if the log buffer is open. Set up some keybinds and you're good to go, please see [here](#tag-management-command-options).
 
 ### Squash changes from the log buffer
 
@@ -447,9 +445,7 @@ The plugin also provides `:Jdiff`, `:Jvdiff`, and `:Jhdiff` commands for diffing
         },
         quick_squash = "<S-s>",             -- Quick squash revision under cursor into its parent (ignore immutability)
         split = "<C-s>",                    -- Split the revision under cursor
-        tag_create = "tt",                  -- Create a tag on the revision under cursor
-        tag_delete = "td",                  -- Delete a tag via picker
-        tag_push = "tp",                    -- Push a tag to remote (colocated repos only)
+        tag_create = "<S-t>",               -- Create a tag on the revision under cursor
         summary = "<S-k>",                  -- Show summary tooltip for revision under cursor
         summary_tooltip = {
             diff = "<S-d>",                   -- Diff file at this revision
@@ -649,7 +645,7 @@ The `tag_push` function pushes a tag to a remote (colocated repositories only):
 
 ```lua
 local cmd = require("jj.cmd")
-cmd.tag_push()             -- Select tag to push (prompts for remote if multiple)
+cmd.tag_push()             -- Select tag to push from picker (prompts for remote if multiple)
 ```
 
 ### Open PR/MR Command Options

--- a/lua/jj/cmd/init.lua
+++ b/lua/jj/cmd/init.lua
@@ -55,9 +55,7 @@ local split_module = require("jj.cmd.split")
 --- @field quick_squash? string|string[]
 --- @field summary? string|string[]
 --- @field summary_tooltip? jj.cmd.summary_tooltip.keymaps
---- @field tag_create? string|string[]
---- @field tag_delete? string|string[]
---- @field tag_push? string|string[]
+--- @field tag_set? string|string[]
 
 --- @class jj.cmd.rebase.keymaps
 --- @field onto? string|string[]
@@ -192,10 +190,7 @@ M.config = {
 				edit_immutable = "<S-CR>",
 			},
 			split = "<C-s>",
-			tag_actions = "<S-t>",
-			tag_create = "tt",
-			tag_delete = "td",
-			tag_push = "tp",
+			tag_set = "<S-t>",
 		},
 		status = {
 			open_file = "<CR>",

--- a/lua/jj/cmd/log.lua
+++ b/lua/jj/cmd/log.lua
@@ -595,16 +595,6 @@ function M.handle_log_tag_set(revset)
 	require("jj.cmd").tag_set(revset)
 end
 
---- Handle deleting a tag from `jj log` buffer for the revision under cursor
-function M.handle_log_tag_delete()
-	require("jj.cmd").tag_delete()
-end
-
--- Handle tag push
-function M.handle_log_tag_push()
-	require("jj.cmd").tag_push()
-end
-
 --- Handle opening a PR/MR from `jj log` buffer for the revision under cursor
 --- @param list_bookmarks? boolean If true, prompt to select from all bookmarks instead of using current revision
 function M.handle_log_open_pr(list_bookmarks)
@@ -1055,19 +1045,9 @@ function M.log_keymaps()
 			handler = M.handle_log_split,
 			modes = { "n" },
 		},
-		tag_create = {
-			desc = "Create a tag under the current revset",
+		tag_set = {
+			desc = "Set a tag under the current revset",
 			handler = M.handle_log_tag_set,
-			modes = { "n" },
-		},
-		tag_delete = {
-			desc = "Opens a picker to delete a specific tag",
-			handler = M.handle_log_tag_delete,
-			modes = { "n" },
-		},
-		tag_push = {
-			desc = "Opens a picker tu push a specific tag on git colocated repositories.",
-			handler = M.handle_log_tag_push,
 			modes = { "n" },
 		},
 	}

--- a/lua/jj/utils.lua
+++ b/lua/jj/utils.lua
@@ -163,7 +163,7 @@ function M.get_all_tags()
 	-- Use a custom template to output just the bookmark names, one per line
 	-- This is more reliable than parsing the default output format
 	local bookmarks_output, success = runner.execute_command(
-		[[jj tag list --sort committer-date- -T 'if(!self.remote(), name ++ if(!self.present(), " (deleted)", "") ++ "\n")']],
+		[[jj tag list --quiet --sort committer-date- -T 'if(!self.remote(), name ++ if(!self.present(), " (deleted)", "") ++ "\n")']],
 		"Failed to get bookmarks",
 		nil,
 		true


### PR DESCRIPTION
Add tag_set, tag_delete, and tag_push commands with full UI integration:
- Create tags on any revision via prompt or log buffer (tt)
- Delete tags via picker selection (td)
- Push tags to remote on colocated repos via git push (tp)
- Add get_all_tags() and is_colocated() utilities
- Register :J tag set/delete cmdline handlers with completion
- Update README with tag documentation, keymaps, and Lua API examples