### PR TITLE
fix: resolve log keymaps when ui.default-command is an array

### DIFF
--- a/lua/jj/cmd/init.lua
+++ b/lua/jj/cmd/init.lua
@@ -833,22 +833,18 @@ function M.j(args)
 	local cmd = nil
 	if #args == 0 then
 		local default_cmd_str, success = runner.execute_command(
-			"jj config get ui.default-command",
+			"jj config list ui.default-command",
 			"Error getting user's default command",
 			nil,
 			true
 		)
-		if not success then
-			terminal.run("jj", M.terminal_keymaps())
-			return
+		if success then
+			cmd = parser.parse_default_cmd(default_cmd_str or "")
 		end
-
-		local default_cmd = parser.parse_default_cmd(default_cmd_str and default_cmd_str or "")
-		if default_cmd == nil then
-			terminal.run("jj", M.terminal_keymaps())
-			return
+		-- jj's built-in default command is "log"
+		if cmd == nil then
+			cmd = { "log" }
 		end
-		cmd = default_cmd
 	end
 
 	if type(args) == "string" then

--- a/lua/jj/core/parser.lua
+++ b/lua/jj/core/parser.lua
@@ -9,8 +9,9 @@ function M.parse_default_cmd(cmd_output)
 		return nil
 	end
 
-	-- Remove whitespace and parse TOML output
+	-- Remove whitespace and strip "key = " prefix from `jj config list` output
 	local trimmed_cmd = vim.trim(cmd_output)
+	trimmed_cmd = trimmed_cmd:gsub("^[%w._-]+ = ", "")
 
 	-- Try to parse as TOML array: ["item1", "item2", ...]
 	-- Pattern "%[(.*)%]" captures everything between square brackets


### PR DESCRIPTION
## What

Use `jj config list` instead of `jj config get` to read `ui.default-command`, and strip the `key =  prefix` in the parser.

## Why

`jj config get` fails when the value is an array (e.g. ["log", "--no-pager"]), causing `:J` to fall back to a bare jj invocation with only the "close" keymap — no diff, summary, or other log keybindings.

## Testing

- nvim -l tests/run_tests.lua — 67 tests pass, including 7 new parse_default_cmd tests covering both config list and config get output formats.
- Manual: `nvim --cmd "set runtimepath^=.../jj.nvim"`. then `:J`, and `g?` shows log keybindings and `Shift-D`/`Shift-K` work.