### PR TITLE
feat: use sync describe when the log buffer should be re-opened

### DIFF
--- a/lua/jj/cmd/describe.lua
+++ b/lua/jj/cmd/describe.lua
@@ -17,7 +17,8 @@ local default_describe_opts = {
 --- Execute jj describe command with the given description
 --- @param description string The description text
 --- @param revset? string The revision to describe
-local function execute_describe(description, revset)
+--- @param sync? boolean Whether to execute command synchronously
+local function execute_describe(description, revset, sync)
 	if not description or description == "" then
 		utils.notify("Description cannot be empty", vim.log.levels.ERROR)
 		return
@@ -30,6 +31,13 @@ local function execute_describe(description, revset)
 	cmd = cmd .. " --stdin"
 
 	-- Use --stdin to properly handle multi-line and special characters
+	if sync then
+		runner.execute_command_sync(cmd, function()
+			utils.notify("Description set.", vim.log.levels.INFO)
+		end, "Failed to describe", description)
+		return
+	end
+
 	runner.execute_command_async(cmd, function()
 		utils.notify("Description set.", vim.log.levels.INFO)
 	end, "Failed to describe", description)
@@ -62,7 +70,7 @@ function M.describe(description, revset, opts, on_close)
 	-- Check if a description was provided otherwise require for input
 	if description then
 		-- Description provided directly
-		execute_describe(description, revset)
+		execute_describe(description, revset, false)
 		return
 	end
 
@@ -90,7 +98,7 @@ function M.describe(description, revset, opts, on_close)
 				-- If nothing is provide simply exit
 				return
 			end
-			execute_describe(trimmed_description, revset)
+			execute_describe(trimmed_description, revset, true)
 			-- Once editing is done, reopen the log if we came from there
 		end, function()
 			-- If an on close callback is provided, call it
@@ -113,7 +121,7 @@ function M.describe(description, revset, opts, on_close)
 		}, function(input)
 			-- If the user inputed something, execute the describe command
 			if input then
-				execute_describe(input, revset)
+				execute_describe(input, revset, true)
 			end
 			-- Close the current terminal when finished
 			terminal.close_terminal_buffer()

--- a/lua/jj/core/runner.lua
+++ b/lua/jj/core/runner.lua
@@ -29,6 +29,22 @@ function M.execute_command(cmd, error_prefix, input, silent)
 	return output, success
 end
 
+--- Execute a system command synchronously and call success callback.
+--- @param cmd string The command to execute
+--- @param on_success function|nil Callback on success, receives output as parameter
+--- @param error_prefix string|nil Optional error message prefix
+--- @param input string|nil Optional input to pass to stdin
+--- @param silent boolean|nil Optional to silent the notification
+--- @return string|nil output The command output, or nil if failed
+--- @return boolean success Whether the command succeeded
+function M.execute_command_sync(cmd, on_success, error_prefix, input, silent)
+	local output, success = M.execute_command(cmd, error_prefix, input, silent)
+	if success and on_success then
+		on_success(output)
+	end
+	return output, success
+end
+
 --- Execute a system command asynchronously
 --- @param cmd string The command to execute
 --- @param on_success function|nil Callback on success, receives output as parameter


### PR DESCRIPTION
## Problem

Currently, jj.nvim processes the commit description asynchronously when it is written via terminal/input from the log buffer, and then returns to the log buffer.

If the log buffer is rendered again before the desc command completes, the changes may not be properly reflected. In practice, this issue occurs intermittently.

## Solution

Introduce a new `execute_command_sync` function to run commands synchronously.
When necessary, use this synchronous runner instead of the asynchronous runner to ensure the description update is fully applied before returning to the log buffer.