### PR TITLE
feat: refresh buffers when moving the change

### DIFF
--- a/lua/jj/cmd/init.lua
+++ b/lua/jj/cmd/init.lua
@@ -370,6 +370,7 @@ function M.edit()
 	}, function(input)
 		if input then
 			runner.execute_command_async(string.format("jj edit %s", input), function()
+				utils.reload_changed_file_buffers()
 				M.log({})
 			end, "Error editing change")
 		else

--- a/lua/jj/cmd/log.lua
+++ b/lua/jj/cmd/log.lua
@@ -397,6 +397,8 @@ function M.handle_log_edit(ignore_immut, close_on_exit)
 
 	-- Try to execute cmd
 	runner.execute_command_async(cmd, function()
+		utils.reload_changed_file_buffers()
+
 		-- Close the terminal buffer
 		if close_on_exit then
 			utils.notify(string.format("Editing change: `%s`", revset), vim.log.levels.INFO)
@@ -817,6 +819,7 @@ function M.handle_summary_edit(revset, ignore_immut)
 	end
 
 	runner.execute_command_async(cmd, function()
+		utils.reload_changed_file_buffers()
 		utils.notify(string.format("Editing revset: `%s`", revset), vim.log.levels.INFO)
 		-- Open the file in the current window
 		vim.cmd("edit " .. vim.fn.fnameescape(filepath.new_path))

--- a/lua/jj/picker/snacks.lua
+++ b/lua/jj/picker/snacks.lua
@@ -149,6 +149,7 @@ function M.file_log_history(opts, log_lines)
 			)
 
 			if ok then
+				utils.reload_changed_file_buffers()
 				utils.notify(string.format("Editing revision `%s`", item.rev), vim.log.levels.INFO)
 			end
 		end,

--- a/lua/jj/utils.lua
+++ b/lua/jj/utils.lua
@@ -690,4 +690,9 @@ function M.extract_description_from_describe(lines)
 	return trimmed_description
 end
 
+--- Reload loaded file buffers after working-copy changes.
+function M.reload_changed_file_buffers()
+	vim.cmd.checktime()
+end
+
 return M


### PR DESCRIPTION
This PR automatically refreshes the currently open buffer to reflect the changes after performing an edit operation in jj.nvim (e.g., :J edit or pressing <CR> on a change in the log buffer).

The buffer refresh is implemented by simply calling vim.cmd.checktime().