### PR TITLE
feat(picker): add <C-d> keybinding to open file and run Jdiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,13 @@ Press `<S-x>` on a file from the `status` output and that's it, it's restored.
 
 ![Restore-status](https://github.com/NicolasGB/jj.nvim/raw/main/assets/x-status.gif)
 
+### Status picker (Snacks.nvim)
+
+When using the [Snacks.nvim](https://github.com/folke/snacks.nvim) picker integration, `picker.status()` opens a fuzzy-findable list of changed files with a live diff preview. Available keybindings:
+
+- `<Enter>` - Open the selected file
+- `<C-d>` - Open the selected file and run `Jdiff`
+
 ## Installation
 
 Using [lazy.nvim](https://github.com/folke/lazy.nvim):

--- a/lua/jj/picker/snacks.lua
+++ b/lua/jj/picker/snacks.lua
@@ -28,6 +28,24 @@ function M.status(opts, files)
 		source = "jj",
 		items = files,
 		title = "JJ Status",
+		actions = {
+			open_and_diff = function(picker, item)
+				picker:close()
+				if item and item.file then
+					vim.schedule(function()
+						vim.cmd("edit " .. vim.fn.fnameescape(item.file))
+						vim.cmd("Jdiff")
+					end)
+				end
+			end,
+		},
+		win = {
+			input = {
+				keys = {
+					["<C-d>"] = { "open_and_diff", mode = { "i", "n" } },
+				},
+			},
+		},
 		preview = function(ctx)
 			if ctx.item.file then
 				snacks.picker.preview.cmd(ctx.item.diff_cmd, ctx, {})


### PR DESCRIPTION
In the status picker, pressing Ctrl-d opens the selected file in the current window and immediately runs :Jdiff, so the diff view follows without a second step.