### PR TITLE
fix(ui): correctly extract the cmd on floating buffers

### DIFF
--- a/lua/jj/ui/terminal.lua
+++ b/lua/jj/ui/terminal.lua
@@ -390,7 +390,7 @@ function M.run_floating(cmd, keymaps, float_opts)
 					end
 					-- Store the subcommand on successful exit
 					if exit_code == 0 then
-						state.floating_buf_cmd = vim.split(cmd, "%s+")[2]
+						state.floating_buf_cmd = cmd[2]
 					end
 					-- Make the bufer optionally not modifiable
 					if not float_opts.keep_modifiable then


### PR DESCRIPTION
Closes #141 