### PR TITLE
feat(cmd): add configurable destructive action confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,9 @@ revision via `jj diffedit`. Immutable revisions show an error on write.
 
   -- Configure cmd module (describe editor, keymaps)
   cmd = {
+    -- Prompt before immediate destructive keymap actions
+    confirm_destructive_actions = true,
+
     -- Configure describe editor
     describe = {
       editor = {
@@ -736,6 +739,20 @@ revision via `jj diffedit`. Immutable revisions show an error on write.
 
 }}
 
+```
+
+### Destructive Action Confirmations
+
+`cmd.confirm_destructive_actions` controls confirmation prompts for destructive actions that execute immediately from a keymap. It defaults to `true` and protects abandoning changes, restoring files from the status buffer, and non-interactive quick squash.
+
+Disable it to run those actions immediately:
+
+```lua
+require("jj").setup({
+  cmd = {
+    confirm_destructive_actions = false,
+  },
+})
 ```
 
 ### Describe Editor Modes

--- a/lua/jj/cmd/init.lua
+++ b/lua/jj/cmd/init.lua
@@ -133,6 +133,7 @@ local resolve_module = require("jj.cmd.resolve")
 ---@field on_exit? fun(exit_code: number) Callback invoked when command exits
 
 --- @class jj.cmd.opts
+--- @field confirm_destructive_actions? boolean Prompt before immediate destructive keymap actions
 --- @field describe? jj.cmd.describe
 --- @field log? jj.cmd.log
 --- @field resolve_strategies? jj.cmd.resolve.strategy[] List of conflict resolve strategies shared across cmd integrations
@@ -164,6 +165,7 @@ local resolve_module = require("jj.cmd.resolve")
 
 --- @type jj.cmd.opts
 M.config = {
+	confirm_destructive_actions = true,
 	describe = {
 		editor = {
 			type = "buffer",

--- a/lua/jj/cmd/log.lua
+++ b/lua/jj/cmd/log.lua
@@ -598,14 +598,20 @@ function M.handle_log_abandon(ignore_immut)
 	table.insert(cmd, revsets)
 
 	-- Try to execute cmd
-	runner.execute_async(cmd, function()
-		local text = "Abandoned change: `%s`"
-		if revsets:find(" ", 1) then
-			text = "Abandoned changes: `%s`"
+	utils.with_confirmation(
+		require("jj.cmd").config.confirm_destructive_actions,
+		("abandon `%s`"):format((revsets:gsub("%s+", " | "))),
+		function()
+			runner.execute_async(cmd, function()
+				local text = "Abandoned change: `%s`"
+				if revsets:find(" ", 1) then
+					text = "Abandoned changes: `%s`"
+				end
+				utils.notify(string.format(text, revsets), vim.log.levels.INFO)
+				M.log({})
+			end, "Error abandoning change")
 		end
-		utils.notify(string.format(text, revsets), vim.log.levels.INFO)
-		M.log({})
-	end, "Error abandoning change")
+	)
 end
 
 --- Handle fetching from `jj log` buffer.
@@ -1022,11 +1028,20 @@ function M.handle_log_quick_squash(interactive)
 			end,
 		})
 	else
-		utils.notify(string.format("Squashing `%s` into it's parent...", revset), vim.log.levels.INFO)
-		runner.execute_async(cmd, function()
-			utils.notify(string.format("Successfully squashed `%s` into it's parent", revset), vim.log.levels.INFO)
-			M.log({})
-		end, string.format("Error squashing `%s` into it's parent", revset))
+		utils.with_confirmation(
+			require("jj.cmd").config.confirm_destructive_actions,
+			("squash `%s` into its parents"):format(revset),
+			function()
+				utils.notify(string.format("Squashing `%s` into it's parent...", revset), vim.log.levels.INFO)
+				runner.execute_async(cmd, function()
+					utils.notify(
+						string.format("Successfully squashed `%s` into it's parent", revset),
+						vim.log.levels.INFO
+					)
+					M.log({})
+				end, string.format("Error squashing `%s` into it's parent", revset))
+			end
+		)
 	end
 end
 

--- a/lua/jj/cmd/status.lua
+++ b/lua/jj/cmd/status.lua
@@ -42,23 +42,37 @@ function M.handle_status_restore()
 		end
 	end
 
-	local _, restore_success = runner.execute(cmd, "Failed to restore original file")
-	if restore_success then
-		local notif_msg = "Restored file:\n"
-		if #files > 1 then
-			notif_msg = "Restored files:\n"
+	local action
+	if #files == 1 then
+		local file = files[1]
+		if file.is_rename then
+			action = ("restore changes to `%s` and `%s`"):format(file.old_path, file.new_path)
+		else
+			action = ("restore changes to `%s`"):format(file.old_path)
 		end
-
-		for _, file in ipairs(files) do
-			if file.is_rename then
-				notif_msg = notif_msg .. "- `" .. file.old_path .. "` -> `" .. file.new_path .. "`\n"
-			else
-				notif_msg = notif_msg .. "- `" .. file.old_path .. "`\n"
-			end
-		end
-		utils.notify(notif_msg, vim.log.levels.INFO)
-		M.status() -- Refresh the status buffer after restoring files
+	else
+		action = ("restore changes to %d files"):format(#files)
 	end
+
+	utils.with_confirmation(require("jj.cmd").config.confirm_destructive_actions, action, function()
+		local _, restore_success = runner.execute(cmd, "Failed to restore original file")
+		if restore_success then
+			local notif_msg = "Restored file:\n"
+			if #files > 1 then
+				notif_msg = "Restored files:\n"
+			end
+
+			for _, file in ipairs(files) do
+				if file.is_rename then
+					notif_msg = notif_msg .. "- `" .. file.old_path .. "` -> `" .. file.new_path .. "`\n"
+				else
+					notif_msg = notif_msg .. "- `" .. file.old_path .. "`\n"
+				end
+			end
+			utils.notify(notif_msg, vim.log.levels.INFO)
+			M.status() -- Refresh the status buffer after restoring files
+		end
+	end)
 end
 
 --- Handle opening a file from the jj status buffer

--- a/lua/jj/utils.lua
+++ b/lua/jj/utils.lua
@@ -1086,4 +1086,28 @@ function M.get_visual_selection(bufnr)
 	return lines, selected_start_line, selected_end_line
 end
 
+--- Invoke an action immediately or after a user confirmation prompt.
+---
+--- When `confirm` is false, `fn` runs immediately. When it is true, `fn` is
+--- invoked only after the user selects "Yes"; choosing "No" or cancelling does
+--- nothing. The confirmed path is asynchronous because it uses `vim.ui.select()`.
+---
+---@param confirm boolean Whether to prompt before invoking `fn`
+---@param action string Description of the action, interpolated into the prompt
+---@param fn fun() Action to invoke after confirmation, or immediately when disabled
+function M.with_confirmation(confirm, action, fn)
+	if not confirm then
+		fn()
+		return
+	end
+
+	vim.ui.select({ "Yes", "No" }, {
+		prompt = ("Do you really want to %s?"):format(action),
+	}, function(choice)
+		if choice == "Yes" then
+			fn()
+		end
+	end)
+end
+
 return M


### PR DESCRIPTION
   Prompt before abandoning revisions, restoring status files, and running
   non-interactive quick squash from keymaps. Add `cmd.confirm_destructive_actions` 
   to disable these prompts.